### PR TITLE
Add win32 compile/linking support for python bindings

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,27 +1,37 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import sys
+
 from setuptools import setup, Extension
 
+EXTENSION_LIBRARIES = ['udbserver']
+LIBRARY_DIRS = []
+INCLUDE_DIRS = []
 
-rust_module = Extension('udbserver',
-                           sources=['udbserver.c'],
-                           libraries=['udbserver'],
-                           )
+if sys.platform in ('win32', 'cygwin'):
+    EXTENSION_LIBRARIES += ['unicorn', 'ws2_32', 'advapi32', 'userenv',
+                            'bcrypt']
+    LIBRARY_DIRS = ['../../build/usr/lib/']
+    INCLUDE_DIRS = ['../../build/usr/include/']
 
-setup (name = 'udbserver',
-       version = '0.1',
-       author = 'Bet4',
-       author_email = '0xbet4@gmail.com',
-       description = 'Python bindings of udbserver',
-       url = 'https://github.com/bet4it/udbserver',
-       license='MIT License',
-       classifiers=[
-           'Intended Audience :: Developers',
-           'License :: OSI Approved :: MIT License',
-           'Programming Language :: Python :: 3',
-           'Topic :: Software Development :: Debuggers',
-       ],
-       ext_modules = [rust_module],
-       py_modules = [],
-       )
+rust_module = Extension('udbserver', sources=['udbserver.c'],
+                        libraries=EXTENSION_LIBRARIES,
+                        library_dirs=LIBRARY_DIRS,
+                        include_dirs=INCLUDE_DIRS)
+
+setup(
+    name='udbserver',
+    version='0.1',
+    author='Bet4',
+    author_email='0xbet4@gmail.com',
+    description='Python bindings of udbserver',
+    url='https://github.com/bet4it/udbserver',
+    license='MIT License',
+    classifiers=['Intended Audience :: Developers',
+                 'License :: OSI Approved :: MIT License',
+                 'Programming Language :: Python :: 3',
+                 'Topic :: Software Development :: Debuggers'],
+    ext_modules=[rust_module],
+    py_modules=[],
+    )


### PR DESCRIPTION
I was able to get this building reliably on my Win 10 x64 system with the proper Windows SDKs installed.

The main problem that I had was making sure the local build was refrencing the correct `.lib` and `.h` files from building UDBServer and then defining the correct win32 lib imports for the linker to not throw errors.

I do not know if this will build/link on other supported platforms, but my changes are designed to only be applied on windows platforms.

Some details about my system are below.

```
Edition:  Windows 10
Version:  22H2
OS build: 19045.2965
```

SDK Url: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
