### PR TITLE
Update the cp command option to avoid risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To build and install it you need to use [cargo-c](https://crates.io/crates/cargo
 $ cargo install cargo-c
 $ mkdir build
 $ cargo cinstall --release --prefix=/usr --destdir build
-$ sudo cp -a build/* /
+$ sudo cp -dr build/* /
 ```
 
 ## Language bindings


### PR DESCRIPTION
`cp -a` is the same as `cp -dR --preserve=all`, which will change the owner of `/usr`, `/usr/lib`, `/usr/include`, which would mess up the entire system in some special situations. There is no need to preserver the ownership, so that it makes more sense to just `sudo cp -dr build/* /`