### PR TITLE
Add support for Unicorn instances with data.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     Ok(stream)
 }
 
-pub fn udbserver(uc: &mut Unicorn<()>, port: u16, start_addr: u64) -> DynResult<()> {
+pub fn udbserver<T>(uc: &mut Unicorn<T>, port: u16, start_addr: u64) -> DynResult<()> {
     let code_hook = uc.add_code_hook(1, 0, |_, _, _| {}).expect("Failed to add empty code hook");
     let mem_hook = uc
         .add_mem_hook(HookType::MEM_READ, 1, 0, |_, _, _, _, _| true)


### PR DESCRIPTION
The code assumed that Unicorn engine instances had no data bound to them (cannot use 
`Unicorn::new_with_data` to build your Unicorn engine instance).  That's a simple fix for the problem and from a quick test it didn't seem to break anything (the C API doesn't care about generics anyway).