### PR TITLE
Fix rle in gdbstub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["lib"]
 capi = []
 
 [dependencies]
-gdbstub = "0.7"
+gdbstub = "0.7.9"
 singlyton = "4"
 unicorn-engine = { version = "2.1.4", features = ["dynamic_linkage"] }
 


### PR DESCRIPTION
GDBclient is not strict enough to catch this, but other debuggers such as idapro struggle if they follow the protocol more strictly

https://github.com/daniel5151/gdbstub/pull/182