### PR TITLE
Fix C binding

### DIFF
--- a/assets/udbserver.h
+++ b/assets/udbserver.h
@@ -1,3 +1,11 @@
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int32_t udbserver(void* handle, uint16_t port, uint64_t start_addr);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added the missing `extern "C" {}` scope around the declaration in `udbserver.h`. Not having this causes linker errors for people using C++.