### PR TITLE
Align macOS wheel tags with deployment targets

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,10 +12,12 @@ jobs:
         include:
           - name: win_amd64
             os: windows-latest
-          - name: macosx_15_0_x86_64
+          - name: macosx_10_12_x86_64
             os: macos-15-intel
-          - name: macosx_15_0_arm64
+            deployment_target: "10.12"
+          - name: macosx_11_0_arm64
             os: macos-15
+            deployment_target: "11.0"
           - name: manylinux2014_i686
             os: ubuntu-latest
             target: i686
@@ -59,8 +61,16 @@ jobs:
         python -m pip install build
 
 
-    - name: '🏗️ Build distribution (Windows/MacOS)'
-      if: matrix.os != 'ubuntu-latest'
+    - name: '🏗️ Build distribution (Windows)'
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd bindings/python
+        python -m build --wheel --config-setting=--build-option=--plat-name=${{ matrix.name }}
+
+    - name: '🏗️ Build distribution (macOS)'
+      if: startsWith(matrix.os, 'macos-')
+      env:
+        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
       run: |
         cd bindings/python
         python -m build --wheel --config-setting=--build-option=--plat-name=${{ matrix.name }}


### PR DESCRIPTION
The wheel workflow was tagging macOS artifacts with the runner OS version (`macosx_15_0`) even though the binaries target older deployment baselines. This updates the macOS wheel build configuration so the wheel tag and `MACOSX_DEPLOYMENT_TARGET` reflect the actual supported minimum OS.

- **macOS platform tags**
  - change Intel wheels from `macosx_15_0_x86_64` to `macosx_10_12_x86_64`
  - change Apple Silicon wheels from `macosx_15_0_arm64` to `macosx_11_0_arm64`

- **Deployment target configuration**
  - add per-matrix deployment targets for macOS builds
  - export `MACOSX_DEPLOYMENT_TARGET` in the macOS wheel build step so linker output matches the advertised compatibility

- **Workflow structure**
  - split the shared Windows/macOS build step so macOS can carry deployment-target-specific environment without affecting other platforms
  - leave Linux and Windows wheel behavior unchanged